### PR TITLE
Update sharedBuffer.hpp to fix clang compilation failure.

### DIFF
--- a/include/vpp/sharedBuffer.hpp
+++ b/include/vpp/sharedBuffer.hpp
@@ -166,7 +166,7 @@ protected:
 
 	struct Entry {
 		ReservationID id {};
-		std::variant<Requirement, Reservation> data;
+		std::variant<Requirement, Reservation> data = Requirement();
 	};
 
 	struct Buffer {


### PR DESCRIPTION
Fixed compilation failure with clang . Added a default value for the Entry variant data. Without it there is no default constructor for Entry and the compilation fails.